### PR TITLE
chore: Use 'serverless deploy' in CI workflows

### DIFF
--- a/.github/workflows/deploy-bookings-api.yml
+++ b/.github/workflows/deploy-bookings-api.yml
@@ -39,4 +39,4 @@ jobs:
 
       - name: Deploy to AWS
         working-directory: ./services/api-reservas
-        run: sls deploy
+        run: serverless deploy

--- a/.github/workflows/deploy-fields-api.yml
+++ b/.github/workflows/deploy-fields-api.yml
@@ -39,4 +39,4 @@ jobs:
 
       - name: Deploy to AWS
         working-directory: ./services/api-canchas
-        run: sls deploy
+        run: serverless deploy

--- a/.github/workflows/deploy-payments-api.yml
+++ b/.github/workflows/deploy-payments-api.yml
@@ -39,4 +39,4 @@ jobs:
 
       - name: Deploy to AWS
         working-directory: ./services/api-pagos
-        run: sls deploy
+        run: serverless deploy

--- a/.github/workflows/deploy-users-api.yml
+++ b/.github/workflows/deploy-users-api.yml
@@ -39,4 +39,4 @@ jobs:
 
       - name: Deploy to AWS
         working-directory: ./services/api-usuarios
-        run: sls deploy
+        run: serverless deploy


### PR DESCRIPTION
I've updated all four of your GitHub Actions workflow files to use the full `serverless deploy` command instead of the `sls deploy` shorthand for better clarity and consistency.