### PR TITLE
fix: Correct CI/CD deployment method for all services

### DIFF
--- a/.github/workflows/deploy-bookings-api.yml
+++ b/.github/workflows/deploy-bookings-api.yml
@@ -30,13 +30,10 @@ jobs:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME }}
           aws-region: us-east-1
 
-      - name: Install Serverless Framework
-        run: npm install -g serverless
-
       - name: Install Dependencies
         working-directory: ./services/api-reservas
         run: npm install
 
       - name: Deploy to AWS
         working-directory: ./services/api-reservas
-        run: serverless deploy
+        run: npx serverless deploy

--- a/.github/workflows/deploy-fields-api.yml
+++ b/.github/workflows/deploy-fields-api.yml
@@ -30,13 +30,10 @@ jobs:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME }} # El usuario debe crear este rol y el secreto en GitHub
           aws-region: us-east-1
 
-      - name: Install Serverless Framework
-        run: npm install -g serverless
-
       - name: Install Dependencies
         working-directory: ./services/api-canchas
         run: npm install
 
       - name: Deploy to AWS
         working-directory: ./services/api-canchas
-        run: serverless deploy
+        run: npx serverless deploy

--- a/.github/workflows/deploy-payments-api.yml
+++ b/.github/workflows/deploy-payments-api.yml
@@ -30,13 +30,10 @@ jobs:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME }}
           aws-region: us-east-1
 
-      - name: Install Serverless Framework
-        run: npm install -g serverless
-
       - name: Install Dependencies
         working-directory: ./services/api-pagos
         run: npm install
 
       - name: Deploy to AWS
         working-directory: ./services/api-pagos
-        run: serverless deploy
+        run: npx serverless deploy

--- a/.github/workflows/deploy-users-api.yml
+++ b/.github/workflows/deploy-users-api.yml
@@ -30,13 +30,10 @@ jobs:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME }} # El usuario debe crear este rol y el secreto en GitHub
           aws-region: us-east-1
 
-      - name: Install Serverless Framework
-        run: npm install -g serverless
-
       - name: Install Dependencies
         working-directory: ./services/api-usuarios
         run: npm install
 
       - name: Deploy to AWS
         working-directory: ./services/api-usuarios
-        run: serverless deploy
+        run: npx serverless deploy

--- a/services/api-canchas/package.json
+++ b/services/api-canchas/package.json
@@ -13,5 +13,8 @@
     "@aws-sdk/lib-dynamodb": "^3.598.0",
     "uuid": "^9.0.1",
     "jsonwebtoken": "^9.0.2"
+  },
+  "devDependencies": {
+    "serverless": "^3.38.0"
   }
 }

--- a/services/api-pagos/package.json
+++ b/services/api-pagos/package.json
@@ -14,5 +14,8 @@
     "@aws-sdk/client-s3": "^3.598.0",
     "@aws-sdk/s3-request-presigner": "^3.598.0",
     "jsonwebtoken": "^9.0.2"
+  },
+  "devDependencies": {
+    "serverless": "^3.38.0"
   }
 }

--- a/services/api-reservas/package.json
+++ b/services/api-reservas/package.json
@@ -13,5 +13,8 @@
     "@aws-sdk/lib-dynamodb": "^3.598.0",
     "uuid": "^9.0.1",
     "jsonwebtoken": "^9.0.2"
+  },
+  "devDependencies": {
+    "serverless": "^3.38.0"
   }
 }

--- a/services/api-usuarios/package.json
+++ b/services/api-usuarios/package.json
@@ -14,5 +14,8 @@
     "bcryptjs": "^2.4.3",
     "uuid": "^9.0.1",
     "jsonwebtoken": "^9.0.2"
+  },
+  "devDependencies": {
+    "serverless": "^3.38.0"
   }
 }


### PR DESCRIPTION
This commit resolves a deployment error in the GitHub Actions workflows. The previous method of installing Serverless Framework globally (`npm install -g serverless`) was brittle and caused a "No version found" error.

The fix implements a more robust and standard approach:
- `serverless` has been added as a `devDependency` to each of the four microservices, locking the framework version for each service.
- The GitHub Actions workflows have been updated to remove the global install step.
- The deploy command has been changed to `npx serverless deploy`, which uses the locally installed and version-pinned Serverless Framework.

This ensures more reliable, predictable, and stable deployments.