### PR TITLE
fix: Remove unused ADMIN_API_KEY from service configuration

### DIFF
--- a/services/api-canchas/serverless.yml
+++ b/services/api-canchas/serverless.yml
@@ -7,7 +7,6 @@ provider:
   runtime: nodejs18.x
   region: us-east-1
   environment:
-    ADMIN_API_KEY: ${ssm:/canchas-app/prod/ADMIN_API_KEY}
     JWT_SECRET: ${ssm:/canchas-app/prod/JWT_SECRET}
     USERS_TABLE: UsersTable # Coupled dependency
   iam:
@@ -25,7 +24,6 @@ provider:
           Action:
             - "ssm:GetParameter"
           Resource:
-            - "arn:aws:ssm:${aws:region}:${aws:accountId}:parameter/canchas-app/prod/ADMIN_API_KEY"
             - "arn:aws:ssm:${aws:region}:${aws:accountId}:parameter/canchas-app/prod/JWT_SECRET"
         - Effect: "Allow"
           Action:

--- a/services/api-reservas/serverless.yml
+++ b/services/api-reservas/serverless.yml
@@ -8,7 +8,6 @@ provider:
   region: us-east-1
   environment:
     JWT_SECRET: ${ssm:/canchas-app/prod/JWT_SECRET}
-    ADMIN_API_KEY: ${ssm:/canchas-app/prod/ADMIN_API_KEY}
     BOOKINGS_TABLE: BookingsTable
   iam:
     role:
@@ -34,7 +33,6 @@ provider:
           Action: "ssm:GetParameter"
           Resource:
             - "arn:aws:ssm:${aws:region}:${aws:accountId}:parameter/canchas-app/prod/JWT_SECRET"
-            - "arn:aws:ssm:${aws:region}:${aws:accountId}:parameter/canchas-app/prod/ADMIN_API_KEY"
 
 functions:
   createBooking:


### PR DESCRIPTION
This commit removes the unused `ADMIN_API_KEY` environment variable and its corresponding AWS SSM parameter permission from the `serverless.yml` files of the `api-canchas` and `api-reservas` services.

This variable was a remnant of the initial, simpler API key authentication system. Since the authorization was upgraded to a more secure JWT + Role-based system, this key is no longer used. Its presence was causing deployment failures because the deploy process was correctly trying to resolve a secret from SSM that no longer needed to exist.

This change cleans up the service configuration and resolves the deployment error.