### PR TITLE
fix(reservas): Correct DynamoDB GSI KeyType from SORT to RANGE

### DIFF
--- a/services/api-reservas/serverless.yml
+++ b/services/api-reservas/serverless.yml
@@ -102,7 +102,7 @@ resources:
               - AttributeName: userId
                 KeyType: HASH
               - AttributeName: bookingDate
-                KeyType: SORT
+                KeyType: RANGE
             Projection:
               ProjectionType: ALL
           - IndexName: field-availability-index
@@ -110,7 +110,7 @@ resources:
               - AttributeName: fieldId_bookingDate # Composite Key
                 KeyType: HASH
               - AttributeName: startTime
-                KeyType: SORT
+                KeyType: RANGE
             Projection:
               ProjectionType: ALL
           - IndexName: status-date-index
@@ -118,7 +118,7 @@ resources:
               - AttributeName: bookingStatus
                 KeyType: HASH
               - AttributeName: createdAt
-                KeyType: SORT
+                KeyType: RANGE
             Projection:
               ProjectionType: ALL
         BillingMode: PAY_PER_REQUEST


### PR DESCRIPTION
This commit fixes a CloudFormation deployment error in the `api-reservas` service. The `KeyType` for sort keys in Global Secondary Indexes was incorrectly specified as `SORT`. The correct value required by AWS CloudFormation and DynamoDB is `RANGE`.

This has been corrected for all three GSIs in `services/api-reservas/serverless.yml`.